### PR TITLE
Update Open Graph and Twitter image URLs to absolute paths

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,13 +31,13 @@
         robots: 'index, follow',
         ogTitle: title,
         ogDescription: description,
-        ogImage: '/meta/dawid_nitka_og.png',
+        ogImage: 'https://www.dawidnitka.com/meta/dawid_nitka_og.png',
         ogUrl: url,
         ogType: 'website',
         ogSiteName: title,
         twitterTitle: title,
         twitterDescription: description,
-        twitterImage: '/meta/dawid_nitka_twitter.png',
+        twitterImage: 'https://www.dawidnitka.com/meta/dawid_nitka_twitter.png',
         twitterCard: 'summary_large_image',
     })
 

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -63,13 +63,13 @@
         robots: 'noindex, nofollow',
         ogTitle: title,
         ogDescription: description,
-        ogImage: '/meta/login_og.png',
+        ogImage: 'https://www.dawidnitka.com/meta/login_og.png',
         ogUrl: url,
         ogType: 'website',
         ogSiteName: title,
         twitterTitle: title,
         twitterDescription: description,
-        twitterImage: '/meta/login_twitter.png',
+        twitterImage: 'https://www.dawidnitka.com/meta/login_twitter.png',
         twitterCard: 'summary_large_image',
     })
 


### PR DESCRIPTION
Absolute paths for Open Graph and Twitter image URLs replace relative paths to ensure proper image rendering across platforms.