### PR TITLE
Fix CSS loading issues in Nuxt configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,7 +37,6 @@ export default defineNuxtConfig({
         prefix: '',
         componentDir: './components/ui'
     },
-    // css: [ '~/assets/styles/main.css' ],
     postcss: {
         plugins: {
             tailwindcss: {},

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,12 +37,15 @@ export default defineNuxtConfig({
         prefix: '',
         componentDir: './components/ui'
     },
-    css: [ '~/assets/styles/main.css' ],
+    // css: [ '~/assets/styles/main.css' ],
     postcss: {
         plugins: {
             tailwindcss: {},
             autoprefixer: {},
         },
+    },
+    tailwindcss: {
+        cssPath: '~/assets/styles/main.css',
     },
     colorMode: {
         preference: 'dark',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,8 +6,6 @@ export default defineNuxtConfig({
     routeRules: {
         // Home generated on demand, revalidates in background, cached for 1 hour (3600 seconds)
         '/': { isr: 3600 },
-        // Would be nice but: https://github.com/nuxt/image/issues/1400
-        // '/_ipx/**': { isr: 3600 },
     },
     modules: [
         '@nuxtjs/tailwindcss',


### PR DESCRIPTION
Repair double CSS loading by updating the Tailwind CSS configuration and remove unnecessary commented imports and rules from the Nuxt configuration.