### PR TITLE
fix: update test slot content to use render function

### DIFF
--- a/components/common/__tests__/Section.nuxt.test.ts
+++ b/components/common/__tests__/Section.nuxt.test.ts
@@ -1,5 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
 
 import Section from '../Section.vue'
 
@@ -7,7 +8,7 @@ describe('Section Component', async () => {
     it('renders correctly', async () => {
         const wrapper = await mountSuspended(Section, {
             slots: {
-                default: '<div class="test-content">Test Content</div>'
+                default: () => h('div', { class: 'test-content' }, 'Test Content')
             }
         })
         expect(wrapper.html()).toMatchSnapshot()
@@ -16,7 +17,7 @@ describe('Section Component', async () => {
     it('renders slot content', async () => {
         const wrapper = await mountSuspended(Section, {
             slots: {
-                default: '<div class="test-content">Test Content</div>'
+                default: () => h('div', { class: 'test-content' }, 'Test Content')
             }
         })
         expect(wrapper.find('.test-content').exists()).toBe(true)

--- a/components/common/__tests__/Typography.nuxt.test.ts
+++ b/components/common/__tests__/Typography.nuxt.test.ts
@@ -7,7 +7,7 @@ describe('Typography Component', async () => {
     it('renders correctly', async () => {
         const wrapper = await mountSuspended(Typography, {
             slots: {
-                default: 'Test Content'
+                default: () => 'Test Content'
             }
         })
         expect(wrapper.html()).toMatchSnapshot()
@@ -18,7 +18,7 @@ describe('Typography Component', async () => {
         const wrapper = await mountSuspended(Typography, {
             props: { tag: 'h2' },
             slots: {
-                default: text
+                default: () => text
             }
         })
         expect(wrapper.find('h2').exists()).toBe(true)
@@ -30,7 +30,7 @@ describe('Typography Component', async () => {
         const wrapper = await mountSuspended(Typography, {
             props: { class: customClass },
             slots: {
-                default: 'Test Content'
+                default: () => 'Test Content'
             }
         })
         expect(wrapper.classes()).toContain(customClass)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "lint": "eslint --ext .js,.jsx,.ts,.tsx,.vue src",
         "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.vue --fix src",
         "typecheck": "nuxt typecheck",
-        "test": "vitest",
+        "test": "vitest --no-file-parallelism",
         "----": "",
         "generate": "nuxt generate",
         "preview": "nuxt preview",


### PR DESCRIPTION
Refactor test cases in Section and Typography components to use
Vue's render function for slot content, improving consistency
and maintainability.