### PR TITLE
Remove robots meta tag and integrate Vercel Speed Insights

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="min-h-screen flex flex-col">
+        <SpeedInsights />
         <LayoutAppHeader />
         <main class="flex-grow">
             <slot />
@@ -7,3 +8,6 @@
         <LayoutAppFooter />
     </div>
 </template>
+<script setup lang="ts">
+    import { SpeedInsights } from '@vercel/speed-insights/nuxt'
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,6 +42,7 @@ export default defineNuxtConfig({
         exclude: [
             '/__tests__/**',
             '/admin/**',
+            '/login',
         ],
     },
     shadcn: {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "supabase": "^2.24.3",
         "supazod": "^2.0.0",
         "tailwindcss-animate": "^1.0.7",
-        "typescript": "~5.8.3",
+        "typescript": "5.9.2",
         "vitest": "3.2.4"
     },
     "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@nuxtjs/supabase": "^1.5.2",
         "@tanstack/vue-table": "^8.20.5",
         "@vee-validate/zod": "^4.15.1",
+        "@vercel/speed-insights": "^1.2.0",
         "@vueuse/core": "^13.3.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",

--- a/pages/legal-notice.vue
+++ b/pages/legal-notice.vue
@@ -39,6 +39,5 @@
     useSeoMeta({
         title: title,
         description: description,
-        robots: 'noindex, nofollow',
     })
 </script>

--- a/pages/privacy-policy.vue
+++ b/pages/privacy-policy.vue
@@ -188,7 +188,6 @@
     useSeoMeta({
         title: title,
         description: description,
-        robots: 'noindex, nofollow',
     })
 
     const { $const } = useNuxtApp()

--- a/yarn.lock
+++ b/yarn.lock
@@ -10758,7 +10758,12 @@ typescript@5.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-typescript@^5.2.2, typescript@^5.7.3, typescript@~5.8.3:
+typescript@5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+typescript@^5.2.2, typescript@^5.7.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,6 +2841,11 @@
     picomatch "^4.0.2"
     resolve-from "^5.0.0"
 
+"@vercel/speed-insights@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.2.0.tgz#1656c3596d4ec02d93d301ca45944c1b9b245186"
+  integrity sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==
+
 "@vitejs/plugin-vue-jsx@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-4.2.0.tgz#2738ec05d4705ed553a107342017192e37351640"


### PR DESCRIPTION
Update the legal and privacy pages by removing the robots meta tag and excluding the login page from the sitemap. Integrate the Vercel Speed Insights component into the default layout and update TypeScript to version 5.9.2.