### PR TITLE
fix: add min-width class to SidebarInset component

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -84,7 +84,7 @@
             </SidebarFooter>
             <SidebarRail />
         </Sidebar>
-        <SidebarInset>
+        <SidebarInset class="min-w-1">
             <LayoutAdminHeader />
             <div class="flex flex-1 flex-col gap-4 p-4 pt-0">
                 <slot />


### PR DESCRIPTION
Updated SidebarInset to include a min-width class for making tables scrollable