### PR TITLE
feat(table): sticky actions column + cursor-pointer on buttons

### DIFF
--- a/app/components/admin/assets/List.vue
+++ b/app/components/admin/assets/List.vue
@@ -101,6 +101,7 @@
         {
             id: 'actions',
             enableHiding: false,
+            meta: { class: 'sticky right-0 z-10 bg-background' },
             cell: ({ row }) => {
                 const item = row.original
 

--- a/app/components/admin/experience/List.vue
+++ b/app/components/admin/experience/List.vue
@@ -96,6 +96,7 @@
         {
             id: 'actions',
             enableHiding: false,
+            meta: { class: 'sticky right-0 z-10 bg-background' },
             cell: ({ row }) => {
                 const item = row.original
 

--- a/app/components/admin/project/List.vue
+++ b/app/components/admin/project/List.vue
@@ -101,6 +101,7 @@
         {
             id: 'actions',
             enableHiding: false,
+            meta: { class: 'sticky right-0 z-10 bg-background' },
             cell: ({ row }) => {
                 const item = row.original
 

--- a/app/components/common/DataTable.vue
+++ b/app/components/common/DataTable.vue
@@ -42,6 +42,7 @@
                         <TableHead
                             v-for="header in headerGroup.headers"
                             :key="header.id"
+                            :class="header.column.columnDef.meta?.class"
                         >
                             <FlexRender
                                 v-if="!header.isPlaceholder"
@@ -57,10 +58,11 @@
                             v-for="row in table.getRowModel().rows"
                             :key="row.id"
                         >
-                            <TableRow :data-state="row.getIsSelected() && 'selected'">
+                            <TableRow class="group" :data-state="row.getIsSelected() && 'selected'">
                                 <TableCell
                                     v-for="cell in row.getVisibleCells()"
                                     :key="cell.id"
+                                    :class="cell.column.columnDef.meta?.class"
                                 >
                                     <FlexRender
                                         :render="cell.column.columnDef.cell"

--- a/app/components/ui/button/index.ts
+++ b/app/components/ui/button/index.ts
@@ -3,7 +3,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 export { default as Button } from './Button.vue'
 
 export const buttonVariants = cva(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
     {
         variants: {
             variant: {

--- a/app/tanstack-table.d.ts
+++ b/app/tanstack-table.d.ts
@@ -1,0 +1,7 @@
+import type { RowData } from '@tanstack/vue-table'
+
+declare module '@tanstack/vue-table' {
+    interface ColumnMeta<_TData extends RowData, _TValue> {
+        class?: string
+    }
+}


### PR DESCRIPTION
## Summary

- Makes the three-dot actions column sticky to the right edge of admin tables (projects, experience, assets) — no more horizontal scrolling required on small screens
- Adds `cursor-pointer` to the base button styles

## How it works

Uses TanStack Table's `meta` field to pass a Tailwind class (`sticky right-0 z-10 bg-background border-l group-hover:bg-muted/50`) to the actions column header and cell. A `ColumnMeta` TypeScript augmentation (`app/tanstack-table.d.ts`) makes `meta.class` type-safe. The shared `DataTable.vue` applies `meta?.class` to `<TableHead>` and `<TableCell>`, and adds `group` to body rows for the hover state to work.

## Test plan

- [x] Open any admin table (`/admin/projects`, `/admin/experience`, `/admin/assets`) on a narrow viewport or with browser devtools mobile emulation
- [x] Scroll the table horizontally — three-dot column stays pinned to the right
- [ ] Hover a row — sticky cell background matches row hover state
- [x] Dropdown opens and functions correctly
- [x] Buttons across the app show pointer cursor on hover