### PR TITLE
fix(security): resolve Dependabot lodash code injection vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
             "minimatch@10>brace-expansion": "^5.0.5",
             "picomatch@2": "^2.3.2",
             "picomatch@4": "^4.0.4",
-            "defu": ">=6.1.5"
+            "defu": ">=6.1.5",
+            "lodash": ">=4.18.0"
         },
         "onlyBuiltDependencies": [
             "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   defu: '>=6.1.5'
+  lodash: '>=4.18.0'
 
 importers:
 
@@ -4508,8 +4509,8 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -8896,7 +8897,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -10250,7 +10251,7 @@ snapshots:
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -10653,7 +10654,7 @@ snapshots:
 
   lodash.upperfirst@4.3.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -12100,7 +12101,7 @@ snapshots:
       chokidar: 3.6.0
       fs-extra: 11.3.4
       inquirer: 8.2.7(@types/node@25.5.0)
-      lodash: 4.17.23
+      lodash: 4.18.1
       ora: 5.4.1
       prettier: 3.0.3
       rxjs: 7.8.2
@@ -12536,7 +12537,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.7.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Added pnpm.overrides for lodash >=4.18.0 (resolves to 4.18.1) to fix:
- Code injection via _.template imports key names (HIGH)
- Prototype pollution via array path bypass in _.unset and _.omit (MODERATE)

Transitive dependency introduced via eslint-plugin-vue, nuxt, supazod, and vue-sonner. Dependabot cannot auto-fix transitive deps for pnpm.

pnpm audit now reports 0 vulnerabilities.

https://claude.ai/code/session_018Ry6u8Hk8yzRN1UENGc8KP