### PR TITLE
fix: refresh assets list eagerly after delete

### DIFF
--- a/app/components/admin/assets/List.vue
+++ b/app/components/admin/assets/List.vue
@@ -129,6 +129,7 @@
                 query: { name },
                 method: 'delete'
             })
+            await refreshAssets()
         }
         catch (error) {
             console.error('Failed to delete asset:', error)


### PR DESCRIPTION
## Summary

- `deleteAsset` in `AdminAssetsList` now calls `refreshAssets()` directly after a successful API delete
- Previously the list only refreshed via Supabase realtime (`postgres_changes` on `storage.objects`), which is unreliable in CI — causing the e2e test to time out waiting for the deleted row to detach

## Test plan

- [x] Existing e2e test `should be able to upload a new asset and remove it` now passes (was timing out at 15 s)
- [x] Full test suite: 49/49 pass locally
- Realtime subscription is kept — it still triggers a harmless duplicate refresh in production