### PR TITLE
fix(deps): upgrade shell-quote to >=1.8.4 (CVE-2026-9277)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
             "defu": ">=6.1.5",
             "lodash": ">=4.18.0",
             "unhead": "~2.1.13",
-            "ws": ">=8.20.1"
+            "ws": ">=8.20.1",
+            "shell-quote": ">=1.8.4"
         },
         "onlyBuiltDependencies": [
             "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
   lodash: '>=4.18.0'
   unhead: ~2.1.13
   ws: '>=8.20.1'
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -5849,8 +5850,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -11431,7 +11432,7 @@ snapshots:
   launch-editor@2.13.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   lazystream@1.0.1:
     dependencies:
@@ -12857,7 +12858,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- **CVE-2026-9277** (Critical): `shell-quote` `quote()` does not escape newlines in object `.op` values, enabling shell command injection.
- `shell-quote` enters the project as a transitive dependency via `launch-editor`.
- Added `"shell-quote": ">=1.8.4"` to `pnpm.overrides` in `package.json` to force the patched version; lockfile updated to resolve `1.8.4`.

## Test plan

- [ ] Verify `pnpm-lock.yaml` resolves `shell-quote` to `1.8.4` (no `1.8.3` entries remain)
- [ ] Run `pnpm install` — no errors
- [ ] Run `pnpm lint` and `pnpm typecheck` — clean

https://claude.ai/code/session_01DJymz27SZK8VzYuvhnNE9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJymz27SZK8VzYuvhnNE9n)_